### PR TITLE
feat: Add command history navigation with arrow keys

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,7 @@ async fn run_app<B: ratatui::backend::Backend>(
                             app.on_key(c);
                         }
                         other_key => {
-                            app.on_key_code(other_key);
+                            app.on_key_code(other_key, key.modifiers);
                         }
                     }
                 }

--- a/src/tui/views/terminal.rs
+++ b/src/tui/views/terminal.rs
@@ -151,7 +151,8 @@ fn draw_command_history(
     let scroll_info = if scroll_offset > 0 {
         format!("Terminal Output (↑{scroll_offset} lines scrolled)")
     } else if total_items > available_height {
-        "Terminal Output (Use ↑↓ to scroll, Home/End for top/bottom)".to_string()
+        "Terminal Output (Use Shift+↑↓ to scroll, ↑↓ for history, Home/End for top/bottom)"
+            .to_string()
     } else {
         "Terminal Output".to_string()
     };

--- a/tests/keyboard_input_tests.rs
+++ b/tests/keyboard_input_tests.rs
@@ -1,4 +1,4 @@
-use crossterm::event::KeyCode;
+use crossterm::event::{KeyCode, KeyModifiers};
 use taskhub::db::init_db;
 use taskhub::tui::app::{App, AppMode};
 
@@ -52,7 +52,7 @@ mod key_handling {
         app.command_filter = "test".to_string();
         app.selected_command_index = 2;
 
-        app.on_key_code(KeyCode::Esc);
+        app.on_key_code(KeyCode::Esc, KeyModifiers::NONE);
 
         assert!(!app.show_command_list);
         assert_eq!(app.command_filter, "");
@@ -64,7 +64,7 @@ mod key_handling {
         let mut app = create_test_app().await;
         app.current_input = "".to_string();
 
-        app.on_key_code(KeyCode::Enter);
+        app.on_key_code(KeyCode::Enter, KeyModifiers::NONE);
 
         // Should not set pending command
         assert!(app.pending_command.is_none());
@@ -75,7 +75,7 @@ mod key_handling {
         let mut app = create_test_app().await;
         app.current_input = "/help".to_string();
 
-        app.on_key_code(KeyCode::Enter);
+        app.on_key_code(KeyCode::Enter, KeyModifiers::NONE);
 
         // Should set pending command and clear input
         assert_eq!(app.pending_command, Some("/help".to_string()));
@@ -90,7 +90,7 @@ mod key_handling {
         app.current_input = "/task add hello".to_string();
         app.show_command_list = true;
 
-        app.on_key_code(KeyCode::Enter);
+        app.on_key_code(KeyCode::Enter, KeyModifiers::NONE);
 
         // Should execute command directly since it's complete
         assert_eq!(app.pending_command, Some("/task add hello".to_string()));
@@ -114,7 +114,7 @@ mod key_handling {
         // by setting up a state where the command would be selected
         let _initial_input = app.current_input.clone();
 
-        app.on_key_code(KeyCode::Enter);
+        app.on_key_code(KeyCode::Enter, KeyModifiers::NONE);
 
         // Since "/ta" doesn't match any complete command patterns, it should try to select from list
         // The exact behavior depends on get_filtered_commands implementation
@@ -126,7 +126,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 5;
 
-        app.on_key_code(KeyCode::Backspace);
+        app.on_key_code(KeyCode::Backspace, KeyModifiers::NONE);
 
         assert_eq!(app.current_input, "hell");
         assert_eq!(app.cursor_position, 4);
@@ -138,7 +138,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 0;
 
-        app.on_key_code(KeyCode::Backspace);
+        app.on_key_code(KeyCode::Backspace, KeyModifiers::NONE);
 
         // Should not change anything
         assert_eq!(app.current_input, "hello");
@@ -151,7 +151,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 2; // Between 'e' and 'l'
 
-        app.on_key_code(KeyCode::Delete);
+        app.on_key_code(KeyCode::Delete, KeyModifiers::NONE);
 
         assert_eq!(app.current_input, "helo");
         assert_eq!(app.cursor_position, 2);
@@ -163,7 +163,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 5; // At end
 
-        app.on_key_code(KeyCode::Delete);
+        app.on_key_code(KeyCode::Delete, KeyModifiers::NONE);
 
         // Should not change anything
         assert_eq!(app.current_input, "hello");
@@ -176,7 +176,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 3;
 
-        app.on_key_code(KeyCode::Left);
+        app.on_key_code(KeyCode::Left, KeyModifiers::NONE);
 
         assert_eq!(app.cursor_position, 2);
     }
@@ -187,7 +187,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 0;
 
-        app.on_key_code(KeyCode::Left);
+        app.on_key_code(KeyCode::Left, KeyModifiers::NONE);
 
         // Should not move beyond beginning
         assert_eq!(app.cursor_position, 0);
@@ -199,7 +199,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 2;
 
-        app.on_key_code(KeyCode::Right);
+        app.on_key_code(KeyCode::Right, KeyModifiers::NONE);
 
         assert_eq!(app.cursor_position, 3);
     }
@@ -210,7 +210,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 5;
 
-        app.on_key_code(KeyCode::Right);
+        app.on_key_code(KeyCode::Right, KeyModifiers::NONE);
 
         // Should not move beyond end
         assert_eq!(app.cursor_position, 5);
@@ -222,7 +222,7 @@ mod key_handling {
         app.show_command_list = true;
         app.selected_command_index = 2;
 
-        app.on_key_code(KeyCode::Up);
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
 
         assert_eq!(app.selected_command_index, 1);
     }
@@ -233,7 +233,7 @@ mod key_handling {
         app.show_command_list = true;
         app.selected_command_index = 0;
 
-        app.on_key_code(KeyCode::Up);
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
 
         // Should not move beyond top
         assert_eq!(app.selected_command_index, 0);
@@ -247,7 +247,7 @@ mod key_handling {
 
         // Note: The actual behavior depends on get_filtered_commands
         // This test verifies the method doesn't crash
-        app.on_key_code(KeyCode::Down);
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
 
         // The exact result depends on the filtered commands length
         // We mainly test that it doesn't panic
@@ -274,7 +274,7 @@ mod key_handling {
                 success: true,
             });
 
-        app.on_key_code(KeyCode::PageUp);
+        app.on_key_code(KeyCode::PageUp, KeyModifiers::NONE);
 
         // Should increase scroll offset by 10 (or to max)
         assert!(app.scroll_offset >= 5);
@@ -285,7 +285,7 @@ mod key_handling {
         let mut app = create_test_app().await;
         app.scroll_offset = 15;
 
-        app.on_key_code(KeyCode::PageDown);
+        app.on_key_code(KeyCode::PageDown, KeyModifiers::NONE);
 
         // Should decrease scroll offset by 10
         assert_eq!(app.scroll_offset, 5);
@@ -297,7 +297,7 @@ mod key_handling {
         app.current_input = "".to_string();
         app.scroll_offset = 5;
 
-        app.on_key_code(KeyCode::Home);
+        app.on_key_code(KeyCode::Home, KeyModifiers::NONE);
 
         // Should go to top of history
         let expected_offset = app.get_total_history_lines().saturating_sub(1);
@@ -310,7 +310,7 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 3;
 
-        app.on_key_code(KeyCode::Home);
+        app.on_key_code(KeyCode::Home, KeyModifiers::NONE);
 
         // Should move cursor to beginning
         assert_eq!(app.cursor_position, 0);
@@ -322,7 +322,7 @@ mod key_handling {
         app.current_input = "".to_string();
         app.scroll_offset = 10;
 
-        app.on_key_code(KeyCode::End);
+        app.on_key_code(KeyCode::End, KeyModifiers::NONE);
 
         // Should go to bottom of history
         assert_eq!(app.scroll_offset, 0);
@@ -334,9 +334,350 @@ mod key_handling {
         app.current_input = "hello".to_string();
         app.cursor_position = 2;
 
-        app.on_key_code(KeyCode::End);
+        app.on_key_code(KeyCode::End, KeyModifiers::NONE);
 
         // Should move cursor to end
         assert_eq!(app.cursor_position, 5);
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_up_arrow() {
+        let mut app = create_test_app().await;
+
+        // Add some command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "file1.txt".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "pwd".to_string(),
+                output: "/home/user".to_string(),
+                timestamp: "12:00:01".to_string(),
+                success: true,
+            });
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "echo hello".to_string(),
+                output: "hello".to_string(),
+                timestamp: "12:00:02".to_string(),
+                success: true,
+            });
+
+        // Start with empty input
+        app.current_input = "".to_string();
+        app.cursor_position = 0;
+
+        // Press Up arrow - should get most recent command
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "echo hello");
+        assert_eq!(app.cursor_position, 10);
+        assert_eq!(app.history_index, Some(2));
+        assert_eq!(app.saved_input, "");
+
+        // Press Up arrow again - should get previous command
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "pwd");
+        assert_eq!(app.cursor_position, 3);
+        assert_eq!(app.history_index, Some(1));
+
+        // Press Up arrow again - should get oldest command
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls");
+        assert_eq!(app.cursor_position, 2);
+        assert_eq!(app.history_index, Some(0));
+
+        // Press Up arrow again - should stay at oldest
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls");
+        assert_eq!(app.cursor_position, 2);
+        assert_eq!(app.history_index, Some(0));
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_down_arrow() {
+        let mut app = create_test_app().await;
+
+        // Add some command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "file1.txt".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "pwd".to_string(),
+                output: "/home/user".to_string(),
+                timestamp: "12:00:01".to_string(),
+                success: true,
+            });
+
+        // Start navigation from oldest command
+        app.history_index = Some(0);
+        app.current_input = "ls".to_string();
+        app.saved_input = "partial".to_string();
+
+        // Press Down arrow - should get newer command
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "pwd");
+        assert_eq!(app.cursor_position, 3);
+        assert_eq!(app.history_index, Some(1));
+
+        // Press Down arrow again - should restore saved input
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "partial");
+        assert_eq!(app.cursor_position, 7);
+        assert_eq!(app.history_index, None);
+
+        // Press Down arrow again - should do nothing (no navigation active)
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "partial");
+        assert_eq!(app.history_index, None);
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_with_partial_input() {
+        let mut app = create_test_app().await;
+
+        // Add command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls -la".to_string(),
+                output: "files".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+
+        // Start with partial input
+        app.current_input = "partial command".to_string();
+        app.cursor_position = 15;
+
+        // Press Up arrow - should save partial input and show history
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls -la");
+        assert_eq!(app.cursor_position, 6);
+        assert_eq!(app.history_index, Some(0));
+        assert_eq!(app.saved_input, "partial command");
+
+        // Press Down arrow - should restore partial input
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "partial command");
+        assert_eq!(app.cursor_position, 15);
+        assert_eq!(app.history_index, None);
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_reset_on_typing() {
+        let mut app = create_test_app().await;
+
+        // Add command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "files".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+
+        // Start history navigation
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls");
+        assert_eq!(app.history_index, Some(0));
+
+        // Type a character - should reset history navigation
+        app.on_key('a');
+        assert_eq!(app.current_input, "lsa");
+        assert_eq!(app.history_index, None);
+        assert_eq!(app.saved_input, "");
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_reset_on_backspace() {
+        let mut app = create_test_app().await;
+
+        // Add command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "files".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+
+        // Start history navigation
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls");
+        assert_eq!(app.history_index, Some(0));
+
+        // Press backspace - should reset history navigation
+        app.on_key_code(KeyCode::Backspace, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "l");
+        assert_eq!(app.history_index, None);
+        assert_eq!(app.saved_input, "");
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_reset_on_delete() {
+        let mut app = create_test_app().await;
+
+        // Add command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "files".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+
+        // Start history navigation
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls");
+        assert_eq!(app.history_index, Some(0));
+        app.cursor_position = 1; // Position between 'l' and 's'
+
+        // Press delete - should reset history navigation
+        app.on_key_code(KeyCode::Delete, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "l");
+        assert_eq!(app.history_index, None);
+        assert_eq!(app.saved_input, "");
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_reset_on_enter() {
+        let mut app = create_test_app().await;
+
+        // Add command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "files".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+
+        // Start history navigation
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "ls");
+        assert_eq!(app.history_index, Some(0));
+
+        // Press enter - should reset history navigation and execute command
+        app.on_key_code(KeyCode::Enter, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "");
+        assert_eq!(app.history_index, None);
+        assert_eq!(app.saved_input, "");
+        assert_eq!(app.pending_command, Some("ls".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_command_history_navigation_empty_history() {
+        let mut app = create_test_app().await;
+
+        // No command history
+        assert!(app.command_history.is_empty());
+
+        // Press Up arrow - should do nothing
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "");
+        assert_eq!(app.history_index, None);
+        assert_eq!(app.saved_input, "");
+
+        // Press Down arrow - should do nothing
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
+        assert_eq!(app.current_input, "");
+        assert_eq!(app.history_index, None);
+        assert_eq!(app.saved_input, "");
+    }
+
+    #[tokio::test]
+    async fn test_shift_up_arrow_scrolls_up() {
+        let mut app = create_test_app().await;
+
+        // Add some command history to make scrolling possible
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "test1".to_string(),
+                output: "output1".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "test2".to_string(),
+                output: "output2".to_string(),
+                timestamp: "12:00:01".to_string(),
+                success: true,
+            });
+
+        app.scroll_offset = 0;
+
+        // Press Shift+Up - should scroll up
+        app.on_key_code(KeyCode::Up, KeyModifiers::SHIFT);
+        assert!(app.scroll_offset > 0);
+
+        // Current input should remain unchanged
+        assert_eq!(app.current_input, "");
+        assert_eq!(app.history_index, None);
+    }
+
+    #[tokio::test]
+    async fn test_shift_down_arrow_scrolls_down() {
+        let mut app = create_test_app().await;
+
+        // Start with some scroll offset
+        app.scroll_offset = 10;
+
+        // Press Shift+Down - should scroll down
+        app.on_key_code(KeyCode::Down, KeyModifiers::SHIFT);
+        assert_eq!(app.scroll_offset, 9);
+
+        // Current input should remain unchanged
+        assert_eq!(app.current_input, "");
+        assert_eq!(app.history_index, None);
+    }
+
+    #[tokio::test]
+    async fn test_shift_down_arrow_at_bottom() {
+        let mut app = create_test_app().await;
+
+        // Start at bottom (scroll_offset = 0)
+        app.scroll_offset = 0;
+
+        // Press Shift+Down - should stay at bottom
+        app.on_key_code(KeyCode::Down, KeyModifiers::SHIFT);
+        assert_eq!(app.scroll_offset, 0);
+    }
+
+    #[tokio::test]
+    async fn test_history_navigation_with_command_list_active() {
+        let mut app = create_test_app().await;
+
+        // Add command history
+        app.command_history
+            .push(taskhub::tui::views::terminal::CommandEntry {
+                command: "ls".to_string(),
+                output: "files".to_string(),
+                timestamp: "12:00:00".to_string(),
+                success: true,
+            });
+
+        // Activate command list
+        app.show_command_list = true;
+        app.selected_command_index = 1;
+
+        // Press Up arrow - should navigate command list, not history
+        app.on_key_code(KeyCode::Up, KeyModifiers::NONE);
+        assert_eq!(app.selected_command_index, 0);
+        assert_eq!(app.current_input, ""); // History navigation should not activate
+        assert_eq!(app.history_index, None);
+
+        // Press Down arrow - should navigate command list
+        app.on_key_code(KeyCode::Down, KeyModifiers::NONE);
+        // The exact behavior depends on get_filtered_commands, but history should not activate
+        assert_eq!(app.history_index, None);
     }
 }


### PR DESCRIPTION
## Summary
Implements command history navigation using Up/Down arrow keys, similar to bash/zsh shells. Moves the previous scrolling functionality to Shift+Up/Down keys to avoid conflicts.

## Key Features
- **↑↓ Arrow Keys**: Navigate through command history (older/newer commands)
- **Shift+↑↓**: Scroll terminal output display 
- **Input Preservation**: Automatically saves partial input when navigating history
- **Smart Reset**: History navigation resets when user types or modifies input
- **Updated UI**: Terminal title reflects new key bindings

## Changes Made
- Enhanced `App` struct with `history_index` and `saved_input` state tracking
- Updated `on_key_code` method signature to accept `KeyModifiers`
- Implemented comprehensive history navigation logic with boundary handling
- Added automatic state reset on user input (typing, backspace, delete, enter)
- Updated terminal output title to show correct key bindings
- Added 12 comprehensive tests covering all navigation scenarios

## Test Coverage
- Basic up/down navigation through multiple commands
- Input preservation and restoration behavior  
- State reset on various user actions (typing, editing, executing)
- Edge cases: empty history, boundary conditions
- Scroll functionality with Shift modifiers
- Command list navigation priority

## Backward Compatibility
- All existing functionality preserved
- Command list navigation (when typing `/`) unchanged
- Terminal scrolling moved to intuitive Shift+Arrow combination
- Home/End keys still work for jumping to top/bottom

## Test Results
- 135 total tests passing (12 new tests added)
- All existing functionality verified
- No clippy warnings
- Pre-commit hooks passed