### PR TITLE
Add Ctrl+R reverse history search functionality

### DIFF
--- a/TASKS.md
+++ b/TASKS.md
@@ -21,7 +21,7 @@
   - Save command history to disk and restore it when the application starts. Store history in a file within the user's data directory, with configurable history size limits. Include timestamps for each command.
 
 ### 4. Reverse History Search
-- [ ] **Implement Ctrl+R reverse history search**
+- [x] **Implement Ctrl+R reverse history search**
   - Add Ctrl+R functionality to search through command history. Display a search prompt that filters history as the user types. Support navigating through matches and executing or editing selected commands.
 
 ### 5. Advanced Cursor Movement

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,7 @@ async fn run_app<B: ratatui::backend::Backend>(
             match app.mode {
                 AppMode::TaskList => {
                     let filtered_commands = app.get_filtered_commands();
+                    let reverse_search_prompt = app.get_reverse_search_prompt();
                     let state = TerminalDisplayState {
                         command_history: &app.command_history,
                         current_input: &app.current_input,
@@ -85,11 +86,15 @@ async fn run_app<B: ratatui::backend::Backend>(
                         input_selection_start: app.input_selection_start,
                         input_selection_end: app.input_selection_end,
                         auto_suggestion: app.auto_suggestion.as_deref(),
+                        reverse_search_active: app.reverse_search_active,
+                        reverse_search_prompt: &reverse_search_prompt,
+                        current_search_result: app.get_current_search_result().map(|x| x.as_str()),
                     };
                     draw_task_list(f, size, &app.tasks, &state);
                 }
                 AppMode::Terminal => {
                     let filtered_commands = app.get_filtered_commands();
+                    let reverse_search_prompt = app.get_reverse_search_prompt();
                     let state = TerminalDisplayState {
                         command_history: &app.command_history,
                         current_input: &app.current_input,
@@ -105,6 +110,9 @@ async fn run_app<B: ratatui::backend::Backend>(
                         input_selection_start: app.input_selection_start,
                         input_selection_end: app.input_selection_end,
                         auto_suggestion: app.auto_suggestion.as_deref(),
+                        reverse_search_active: app.reverse_search_active,
+                        reverse_search_prompt: &reverse_search_prompt,
+                        current_search_result: app.get_current_search_result().map(|x| x.as_str()),
                     };
                     draw_terminal(f, size, &state);
                 }
@@ -132,6 +140,11 @@ async fn run_app<B: ratatui::backend::Backend>(
                     {
                         // Handle Ctrl-V for paste
                         let _ = app.paste_from_clipboard();
+                    } else if key.code == KeyCode::Char('r')
+                        && key.modifiers.contains(KeyModifiers::CONTROL)
+                    {
+                        // Handle Ctrl-R for reverse search
+                        app.on_key_code(key.code, key.modifiers);
                     } else {
                         match key.code {
                             KeyCode::Char(c) => {

--- a/tests/ctrl_r_integration_test.rs
+++ b/tests/ctrl_r_integration_test.rs
@@ -1,0 +1,103 @@
+use crossterm::event::{KeyCode, KeyModifiers};
+use taskhub::db::init_db;
+use taskhub::tui::app::App;
+
+#[tokio::test]
+async fn test_ctrl_r_key_event_handling() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    // Add some test history first
+    app.persistent_command_history = vec![
+        "git status".to_string(),
+        "cargo build".to_string(),
+        "ls -la".to_string(),
+    ];
+
+    // Verify reverse search is initially inactive
+    assert!(!app.reverse_search_active);
+
+    // Simulate Ctrl+R key event (this is what the main event loop would call)
+    app.on_key_code(KeyCode::Char('r'), KeyModifiers::CONTROL);
+
+    // Verify reverse search is now active
+    assert!(app.reverse_search_active);
+    assert_eq!(app.reverse_search_query, "");
+    assert_eq!(app.reverse_search_results, Vec::<String>::new());
+
+    // Test that we can add to the search query
+    app.handle_terminal_input('g');
+    app.handle_terminal_input('i');
+    app.handle_terminal_input('t');
+    assert_eq!(app.reverse_search_query, "git");
+    assert_eq!(app.reverse_search_results.len(), 1); // "git status"
+    assert_eq!(app.reverse_search_results[0], "git status");
+
+    // Test that we can navigate and accept
+    let current_result = app.get_current_search_result().unwrap().clone();
+    app.accept_reverse_search();
+    assert!(!app.reverse_search_active);
+    assert_eq!(app.current_input, current_result);
+}
+
+#[tokio::test]
+async fn test_escape_cancels_reverse_search() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    // Start reverse search
+    app.on_key_code(KeyCode::Char('r'), KeyModifiers::CONTROL);
+    assert!(app.reverse_search_active);
+
+    // Type some query
+    app.handle_terminal_input('t');
+    app.handle_terminal_input('e');
+    app.handle_terminal_input('s');
+    app.handle_terminal_input('t');
+    assert_eq!(app.reverse_search_query, "test");
+
+    // Press Escape to cancel
+    app.on_key_code(KeyCode::Esc, KeyModifiers::empty());
+    assert!(!app.reverse_search_active);
+    assert_eq!(app.reverse_search_query, "");
+    assert_eq!(app.reverse_search_results, Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn test_reverse_search_navigation() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    // Add test history with multiple matching commands
+    app.persistent_command_history = vec![
+        "git log".to_string(),
+        "git status".to_string(),
+        "git commit".to_string(),
+    ];
+
+    // Start reverse search and search for "git"
+    app.on_key_code(KeyCode::Char('r'), KeyModifiers::CONTROL);
+    app.handle_terminal_input('g');
+    app.handle_terminal_input('i');
+    app.handle_terminal_input('t');
+
+    // Should have 3 results, starting with most recent (git commit)
+    assert_eq!(app.reverse_search_results.len(), 3);
+    assert_eq!(app.reverse_search_index, 0);
+    assert_eq!(app.get_current_search_result().unwrap(), "git commit");
+
+    // Navigate down (to next older match)
+    app.on_key_code(KeyCode::Down, KeyModifiers::empty());
+    assert_eq!(app.reverse_search_index, 1);
+    assert_eq!(app.get_current_search_result().unwrap(), "git status");
+
+    // Navigate down again
+    app.on_key_code(KeyCode::Down, KeyModifiers::empty());
+    assert_eq!(app.reverse_search_index, 2);
+    assert_eq!(app.get_current_search_result().unwrap(), "git log");
+
+    // Navigate up (to newer match)
+    app.on_key_code(KeyCode::Up, KeyModifiers::empty());
+    assert_eq!(app.reverse_search_index, 1);
+    assert_eq!(app.get_current_search_result().unwrap(), "git status");
+}

--- a/tests/reverse_search_tests.rs
+++ b/tests/reverse_search_tests.rs
@@ -1,0 +1,127 @@
+use taskhub::db::init_db;
+use taskhub::tui::app::App;
+
+#[tokio::test]
+async fn test_reverse_search_functionality() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    // Add some test history
+    app.persistent_command_history = vec![
+        "ls -la".to_string(),
+        "git status".to_string(),
+        "cargo build".to_string(),
+        "ls -la /home".to_string(),
+        "git commit -m 'test'".to_string(),
+    ];
+
+    // Test starting reverse search
+    assert!(!app.reverse_search_active);
+    app.start_reverse_search();
+    assert!(app.reverse_search_active);
+    assert_eq!(app.reverse_search_query, "");
+    assert_eq!(app.reverse_search_results, Vec::<String>::new());
+
+    // Test searching for "git"
+    app.reverse_search_query = "git".to_string();
+    app.update_reverse_search();
+    assert_eq!(app.reverse_search_results.len(), 2);
+    assert_eq!(app.reverse_search_results[0], "git commit -m 'test'"); // Most recent first
+    assert_eq!(app.reverse_search_results[1], "git status");
+
+    // Test navigation
+    assert_eq!(app.reverse_search_index, 0);
+    app.reverse_search_next();
+    assert_eq!(app.reverse_search_index, 1);
+    app.reverse_search_previous();
+    assert_eq!(app.reverse_search_index, 0);
+
+    // Test bounds checking
+    app.reverse_search_previous();
+    assert_eq!(app.reverse_search_index, 0); // Should not go below 0
+    app.reverse_search_next();
+    app.reverse_search_next();
+    assert_eq!(app.reverse_search_index, 1); // Should not go beyond length
+
+    // Test accepting search result
+    let selected_result = app.get_current_search_result().unwrap().clone();
+    app.accept_reverse_search();
+    assert!(!app.reverse_search_active);
+    assert_eq!(app.current_input, selected_result);
+    assert_eq!(app.cursor_position, selected_result.chars().count());
+
+    // Test canceling search
+    app.start_reverse_search();
+    app.reverse_search_query = "test".to_string();
+    app.cancel_reverse_search();
+    assert!(!app.reverse_search_active);
+    assert_eq!(app.reverse_search_query, "");
+    assert_eq!(app.reverse_search_results, Vec::<String>::new());
+}
+
+#[tokio::test]
+async fn test_reverse_search_case_insensitive() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    app.persistent_command_history = vec![
+        "Git Status".to_string(),
+        "GIT COMMIT".to_string(),
+        "git log".to_string(),
+    ];
+
+    app.start_reverse_search();
+    app.reverse_search_query = "git".to_string();
+    app.update_reverse_search();
+
+    assert_eq!(app.reverse_search_results.len(), 3);
+    assert!(app.reverse_search_results.contains(&"git log".to_string()));
+    assert!(
+        app.reverse_search_results
+            .contains(&"GIT COMMIT".to_string())
+    );
+    assert!(
+        app.reverse_search_results
+            .contains(&"Git Status".to_string())
+    );
+}
+
+#[tokio::test]
+async fn test_reverse_search_no_matches() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    app.persistent_command_history = vec!["ls -la".to_string(), "cargo build".to_string()];
+
+    app.start_reverse_search();
+    app.reverse_search_query = "nonexistent".to_string();
+    app.update_reverse_search();
+
+    assert_eq!(app.reverse_search_results.len(), 0);
+    assert!(app.get_current_search_result().is_none());
+}
+
+#[tokio::test]
+async fn test_reverse_search_prompt_generation() {
+    let db_pool = init_db(None).await.unwrap();
+    let mut app = App::new(db_pool.clone());
+
+    // Test when not active
+    assert!(!app.reverse_search_active);
+    assert_eq!(app.get_reverse_search_prompt(), "");
+
+    // Test when active with no query
+    app.start_reverse_search();
+    let prompt = app.get_reverse_search_prompt();
+    assert!(prompt.contains("reverse-i-search"));
+    assert!(prompt.contains("no matches"));
+
+    // Test when active with results
+    app.persistent_command_history = vec!["test command".to_string()];
+    app.reverse_search_query = "test".to_string();
+    app.update_reverse_search();
+    let prompt = app.get_reverse_search_prompt();
+    assert!(prompt.contains("reverse-i-search"));
+    assert!(prompt.contains("1/1"));
+    assert!(prompt.contains("test"));
+}


### PR DESCRIPTION
## Summary

- Implement reverse search mode with Ctrl+R activation for searching through command history
- Add search query filtering that works case-insensitively across both session and persistent history
- Support Up/Down arrow navigation between search results with visual feedback
- Add Esc to cancel and Enter to accept functionality
- Display search prompt with match count in distinctive magenta border
- Filter history with most recent matches appearing first for intuitive navigation

## Implementation Details

- **New App State**: Added reverse search fields to track active state, query, results, and current index
- **Key Handling**: Enhanced key event processing to handle Ctrl+R activation and search-specific navigation
- **UI Updates**: Modified terminal display to show search prompt and current result with visual distinction
- **Search Logic**: Implemented case-insensitive filtering across combined command history with proper result ordering
- **Navigation**: Added up/down arrow support for moving between search results with bounds checking

## Test Coverage

- Added comprehensive integration tests for key event handling
- Added unit tests for search functionality, navigation, and edge cases
- Verified case-insensitive matching and proper result ordering
- Tested boundary conditions and error scenarios

## Test Plan

- [x] Verify Ctrl+R activates reverse search mode
- [x] Test typing characters updates search query and filters results
- [x] Confirm Up/Down arrows navigate between search results
- [x] Validate Esc cancels search and returns to normal mode
- [x] Check Enter accepts current result and populates input field
- [x] Test case-insensitive search matching
- [x] Verify proper handling of no matches scenario
- [x] Confirm visual feedback with magenta border and match count display